### PR TITLE
Fix for checking Finish test in Testdroid Cloud after 'Timeout for resul...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.0.8
+=====
+* Fix for checking "Finish test in Testdroid Cloud after 'Timeout for results’"
+
 1.0.7
 =====
 * Handle NumberFormatException, when Device group is not chosen

--- a/src/main/java/com/testdroid/jenkins/RunInCloudBuilder.java
+++ b/src/main/java/com/testdroid/jenkins/RunInCloudBuilder.java
@@ -738,6 +738,14 @@ public class RunInCloudBuilder extends AbstractBuilder {
         public void setTestRunStateCheckMethod(TestRunStateCheckMethod testRunStateCheckMethod) {
             this.testRunStateCheckMethod = testRunStateCheckMethod;
         }
+
+        public boolean isForceFinishAfterBreak() {
+            return forceFinishAfterBreak;
+        }
+
+        public void setForceFinishAfterBreak(boolean forceFinishAfterBreak) {
+            this.forceFinishAfterBreak = forceFinishAfterBreak;
+        }
     }
 
     @Extension


### PR DESCRIPTION
...ts’